### PR TITLE
Форма редактора реквизитов объекта не открывается для след. объ. №440

### DIFF
--- a/src/Инструменты/src/DataProcessors/УИ_РедакторРеквизитовОбъекта/Forms/ФормаОбъекта/Form.form
+++ b/src/Инструменты/src/DataProcessors/УИ_РедакторРеквизитовОбъекта/Forms/ФормаОбъекта/Form.form
@@ -4865,6 +4865,13 @@
     <representation>TextPicture</representation>
     <currentRowUse>Auto</currentRowUse>
   </formCommands>
+  <parameters>
+    <name>мОбъектСсылка</name>
+    <valueType>
+      <types>AnyRef</types>
+    </valueType>
+    <keyParameter>true</keyParameter>
+  </parameters>
   <commandInterface>
     <navigationPanel/>
     <commandBar/>


### PR DESCRIPTION
#440 
-- на форме ФормаОбъекта обработки УИ_РедакторРеквизитовОбъекта добавлен
__ключевой__ параметр мОбъектСсылка с типом ЛюбаяСсылка. Благодаря
ключевому параметру для каждого переданного в инструмент объекта открывается новая форма обработки