### PR TITLE
Исправлена проблема с получением количества записей в таблицах PostgreSQL в УИ_СтруктураХраненияБазыДанных.

### DIFF
--- a/src/Инструменты/src/DataProcessors/УИ_СтруктураХраненияБазыДанных/Forms/ФормаУправляемая/Module.bsl
+++ b/src/Инструменты/src/DataProcessors/УИ_СтруктураХраненияБазыДанных/Forms/ФормаУправляемая/Module.bsl
@@ -407,7 +407,7 @@
 		ТекстЗапроса =
 		"SELECT
 		|tablename AS table_name,
-		|pg_class.reltuples as records_count,
+		|pg_class.reltuples::bigint as records_count,
 		|pg_total_relation_size(schemaname||'.'||tablename) / 1024 AS total_usage_kb,
 		|pg_table_size(schemaname||'.'||tablename) / 1024 AS table_usage_kb,
 		|pg_indexes_size(schemaname||'.'||tablename) / 1024 as index_usage_kb,


### PR DESCRIPTION
Колонка records_count имеет тип float4, и, при сохранении в CSV для нее используется экспоненциальная запись числа, которая не обрабатывается в УИ_СтроковыеФункцииКлиентСервер.СтрокаВЧисло.

Если поменять тип на bigint (==int8), то число сохраняется в CSV без использования экспоненциальной записи.

total_usage_kb, table_usage_kb, index_usage_kb, и table_free_kb из запроса имеют тип int8, так что с ними не должны быть проблем.

Проверено с PostgreSQL 18.1_2, работающей на Ubuntu 24.04, и psql на Windows и Linux.

Close #748.